### PR TITLE
set StartDate and EndDate from flags

### DIFF
--- a/cmd/gocal/gocal.go
+++ b/cmd/gocal/gocal.go
@@ -82,8 +82,8 @@ func main() {
 			for index, e := range evts {
 				e.StartTime = *insertStart
 				e.EndTime = *insertEnd
-				e.StartTime = *insertStartDate
-				e.EndTime = *insertEndDate
+				e.StartDate = *insertStartDate
+				e.EndDate = *insertEndDate
 				evts[index] = e
 			}
 			gc.InsertEvents(evts)


### PR DESCRIPTION
StartTime and EndTime are overrided by xxxDate. Therefore these values will be nil when --start-date or --end-date is not set.

I got error from API.
> [Error] googleapi: Error 400: Start and end times must either both be date or both be dateTime., invalid

